### PR TITLE
Provide zero-cost Optioned<char>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -882,6 +882,16 @@ impl Noned for f64 {
     fn get_none() -> f64 { std::f64::NAN }
 }
 
+impl Noned for char {
+    #[inline]
+    fn is_none(&self) -> bool { *self as u32 == std::u32::MAX }
+    
+    #[inline]
+    // Because the value is never used as a char but only as a sentinel,
+    // this is safe and provides Optioned<char> with no loss in representation
+    fn get_none() -> char { unsafe { std::char::from_u32_unchecked(std::u32::MAX) } }
+}
+
 ///Equality within Optioned
 pub trait OptEq {
     /// Is the other optioned equal to this one?
@@ -911,6 +921,8 @@ impl OptEq for f64 {
         if self.is_nan() { other.is_nan() } else { self == other }
     }
 }
+
+impl OptEq for char { fn opt_eq(&self, other: &Self) -> bool { self == other } }
 
 ///Ordering within Optioned
 pub trait OptOrd {
@@ -974,6 +986,10 @@ impl OptOrd for f32 {
 }
 impl OptOrd for f64 {
     fn opt_cmp(&self, other: &Self) -> Ordering { _opt_cmp_part(self, other) }
+}
+
+impl OptOrd for char {
+    fn opt_cmp(&self, other: &Self) -> Ordering { _opt_cmp(self, other) }
 }
 
 


### PR DESCRIPTION
This uses `char::from_u32_unsafe(u32::MAX)` as the none value. This is not a valid `char` value, and will never be a valid Unicode code point. Because of this, it is possible to provide a zero cost `Optioned<char>` by assigning the `Noned` value to this invalid code point.

So long as `Optioned` holds its contract of not giving out the noned value, this can in no way be memory unsafe because the fake char is only used as a sentinel, and never as an actual character.