### PR TITLE
Removed code coverage badge since that is not currently being used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Optional
 
 [![Build Status](https://travis-ci.org/llogiq/optional.svg)](https://travis-ci.org/llogiq/optional)
-[![Coverage Status](https://coveralls.io/repos/llogiq/optional/badge.svg?branch=master&service=github)](https://coveralls.io/github/llogiq/optional?branch=master)
 [![Current Version](http://meritbadge.herokuapp.com/optional)](https://crates.io/crates/optional)
 [![License: MIT/Apache](https://img.shields.io/crates/l/optional.svg)](#license)
 


### PR DESCRIPTION
Badge is stale, coveralls.io is no longer used in the crate from my inspection.