### PR TITLE
No more unsafe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,13 +4,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "dtoa"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "itoa"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -18,28 +13,33 @@ name = "optional"
 version = "0.4.3"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "ryu"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "serde"
-version = "1.0.43"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_json"
-version = "1.0.16"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
 "checksum bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
-"checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
-"checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
-"checksum serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "0c855d888276f20d140223bd06515e5bf1647fd6d02593cb5792466d9a8ec2d0"
-"checksum serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8c6c4e049dc657a99e394bd85c22acbf97356feeec6dbf44150f2dcf79fb3118"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
+"checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
+"checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ path = "src/lib.rs"
 unstable = []
 
 [dependencies]
-serde = { version = "1.0.43", optional = true }
+serde = { version = "1.0.80", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.5"
-serde_json = "1.0.16"
+serde_json = "1.0.33"
 
 [[bench]]
 name = "optbool"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 // or distributed except according to those terms.
 
 //! # Space-efficient optional values
-//! 
+//!
 //! ## Booleans
 //!
 //! Type `OptionBool` represents an optional boolean value, similar to
@@ -21,16 +21,16 @@
 //! ```
 //! However, since this crate was originally authored, [improvements in the
 //! compiler](https://users.rust-lang.org/t/list-of-fundamental-crates/17806/5?u=ryan)
-//! have built in this optimization for `Option<bool>` as well. The 
+//! have built in this optimization for `Option<bool>` as well. The
 //! `OptionBool` type remains however because it [may still perform faster in
-//! some bench marks](https://github.com/llogiq/optional/issues/33). 
-//! 
+//! some bench marks](https://github.com/llogiq/optional/issues/33).
+//!
 //! ```rust
 //! assert!(1 == std::mem::size_of::<Option<bool>>());
 //! ```
 //!
 //! ## Any type can be optional
-//! 
+//!
 //! Then there is the `Optioned<T>` type which wraps a type `T` as an optional
 //! value of `T` where one particular value represents None. `Optioned<T>`
 //! requires the exact same space as T:
@@ -51,9 +51,10 @@
 //!
 //! Using Optioned for your own types is as simple as implementing `Noned` for
 //! your type, provided that your type is already Copy and Sized.
-//! 
+//!
 
 #![deny(missing_docs)]
+#![deny(unsafe_code)]
 
 #[cfg(feature = "serde")]
 extern crate serde;
@@ -1335,22 +1336,6 @@ where
     }
 }
 
-mod slice_of_up_to_one {
-    /// Get a slice of zero or one elements from a ref to the single value and a bool whether
-    /// the value should be included
-    ///
-    /// note: This is safe because:
-    ///
-    /// ```rust
-    /// assert_eq!(0, false as usize); // empty slice
-    /// assert_eq!(1, true as usize); // slice of one element
-    /// ```
-    #[inline]
-    pub fn slice_of<T>(value: &T, one: bool) -> &[T] {
-        unsafe { ::std::slice::from_raw_parts(value, one as usize) }
-    }
-}
-
 impl<T: Noned + Copy> Optioned<T> {
     /// Create an `Optioned<T>` that is `some(t)`.
     ///
@@ -1391,21 +1376,21 @@ impl<T: Noned + Copy> Optioned<T> {
     }
 
     /// Convenience funtion to convert an `Optioned` into an `Option`.
-    /// 
-    /// Techinically this is possible with the `Into<Option<T>>` implementation in this crate. 
-    /// However, experience has shown that there are many cases where the compiler isn't able to 
-    /// infer the correct type for the generic parameter and issues an error. As a workaround you 
+    ///
+    /// Techinically this is possible with the `Into<Option<T>>` implementation in this crate.
+    /// However, experience has shown that there are many cases where the compiler isn't able to
+    /// infer the correct type for the generic parameter and issues an error. As a workaround you
     /// can use `Into::<Option<T>>::into(...)` or `.map(|inner| inner)` which will both work.
-    /// The first is verbose and the second makes the intention less clear, so this method is 
+    /// The first is verbose and the second makes the intention less clear, so this method is
     /// provided as a convenience.
-    /// 
+    ///
     /// ```rust
     ///# use optional::some;
     /// if let Some(val) = some(15).into_option() {
     ///     println!("val = {}", val);
     /// }
     /// ```
-    /// 
+    ///
     /// The following example will fail to compile because of type inference.
     /// ```compile_fail
     /// # use optional::some;
@@ -1692,7 +1677,7 @@ impl<T: Noned + Copy> Optioned<T> {
     }
 
     /// Returns the `None` value for type `U` if this value or `other` contains their respective
-    /// `None` values. Otherwise returns the `other` `Optioned` struct. 
+    /// `None` values. Otherwise returns the `other` `Optioned` struct.
     ///
     /// # Examples
     ///
@@ -1729,7 +1714,7 @@ impl<T: Noned + Copy> Optioned<T> {
     /// fn add_two(val: u32) -> Optioned<u32> {
     ///   wrap( val + 2)
     /// }
-    /// 
+    ///
     /// fn failed_function(val: u32) -> Optioned<u32> {
     ///   none()
     /// }
@@ -1759,7 +1744,7 @@ impl<T: Noned + Copy> Optioned<T> {
     ///
     /// ```rust
     /// # use optional::{Optioned, some, none};
-    /// 
+    ///
     /// let x = some(42u32);
     /// assert_eq!(x.ok_or("was none"), Ok(42u32));
     ///
@@ -1782,7 +1767,7 @@ impl<T: Noned + Copy> Optioned<T> {
     ///
     /// ```rust
     /// # use optional::{Optioned, some, none};
-    /// 
+    ///
     /// let x = some(42u32);
     /// assert_eq!(x.ok_or_else(|| "was none"), Ok(42u32));
     ///
@@ -1824,7 +1809,7 @@ impl<T: Noned + Copy> Optioned<T> {
     /// ```
     #[inline]
     pub fn as_slice(&self) -> &[T] {
-        slice_of_up_to_one::slice_of(&self.value, self.is_some())
+        &std::slice::from_ref(&self.value)[..self.is_some() as usize]
     }
 
     /// return an iterator over all contained (that is zero or one) values.


### PR DESCRIPTION
This uses the new `std::slice::from_ref` function to get rid of the single unsafe in this crate without losing any performance in the process.

I also update serde.